### PR TITLE
Filter out empty baseurls

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ console.log(chalk.red('-------------------------'));
 console.log(chalk.cyan('Initializing (' + sites.length + ') sites.'));
 console.log(chalk.red('-------------------------'));
 
-sites.forEach(function (site) {
+sites.filter(function (element) {
+  return element.length > 0
+}).forEach(function (site) {
   startmod = new mod(site);
 });
 


### PR DESCRIPTION
Newlines are being read as empty urls which is causing errors https://github.com/aarock1234/shopify-monitor/issues/5 and https://github.com/aarock1234/shopify-monitor/issues/4. 

The fix solves these issues - however it does not provide adequate validation of URL structure.